### PR TITLE
Add MusicKit lyrics example

### DIFF
--- a/Glyrics/Glyrics/ContentView.swift
+++ b/Glyrics/Glyrics/ContentView.swift
@@ -6,16 +6,33 @@
 //
 
 import SwiftUI
+import MusicKit
 
 struct ContentView: View {
+    @State private var song: Song?
+
     var body: some View {
-        VStack {
-            Image(systemName: "globe")
-                .imageScale(.large)
-                .foregroundStyle(.tint)
-            Text("Hello, world!")
+        VStack(alignment: .leading) {
+            if let song {
+                LyricsView(song: song)
+                    .frame(maxHeight: 200)
+
+                VStack(alignment: .leading, spacing: 8) {
+                    Text("Phonetic line 1\nPhonetic line 2")
+                    Text("Word-by-word translation line 1\nWord-by-word translation line 2")
+                    Text("Actual translation line 1\nActual translation line 2")
+                }
+                .padding()
+            } else {
+                ProgressView()
+            }
         }
-        .padding()
+        .task {
+            let request = MusicCatalogResourceRequest<Song>(matching: \.id, equalTo: MusicItemID("APPLE_MUSIC_TRACK_ID"))
+            if let response = try? await request.response() {
+                song = response.items.first
+            }
+        }
     }
 }
 

--- a/README.md
+++ b/README.md
@@ -1,1 +1,3 @@
 # Glyrics
+
+This sample SwiftUI project demonstrates using MusicKit to display the official lyrics of a song along with phonetic and translated versions. Replace `APPLE_MUSIC_TRACK_ID` in `ContentView.swift` with the Apple Music track ID for "Χωρίς το μωρό μου" by Anna Vissi.


### PR DESCRIPTION
## Summary
- flesh out README with project description
- implement example `ContentView` that fetches a song from Apple Music and shows lyrics with additional custom text

## Testing
- `xcodebuild -list` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_b_6882a7ca0a888330b7adc0a9226ae3e2