### PR TITLE
Add playback and alternate lyrics toggle

### DIFF
--- a/Glyrics/Glyrics/ContentView.swift
+++ b/Glyrics/Glyrics/ContentView.swift
@@ -7,9 +7,11 @@
 
 import SwiftUI
 import MusicKit
+import MusicKitUI
 
 struct ContentView: View {
     @State private var song: Song?
+    @State private var showAlternateLyrics = false
 
     var body: some View {
         VStack(alignment: .leading) {
@@ -17,12 +19,19 @@ struct ContentView: View {
                 LyricsView(song: song)
                     .frame(maxHeight: 200)
 
-                VStack(alignment: .leading, spacing: 8) {
-                    Text("Phonetic line 1\nPhonetic line 2")
-                    Text("Word-by-word translation line 1\nWord-by-word translation line 2")
-                    Text("Actual translation line 1\nActual translation line 2")
+                if showAlternateLyrics {
+                    VStack(alignment: .leading, spacing: 8) {
+                        Text("Phonetic line 1\nPhonetic line 2")
+                        Text("Word-by-word translation line 1\nWord-by-word translation line 2")
+                        Text("Actual translation line 1\nActual translation line 2")
+                    }
+                    .padding()
                 }
-                .padding()
+
+                Button(showAlternateLyrics ? "Hide Alternate Lyrics" : "Show Alternate Lyrics") {
+                    showAlternateLyrics.toggle()
+                }
+                .padding(.top)
             } else {
                 ProgressView()
             }
@@ -31,6 +40,11 @@ struct ContentView: View {
             let request = MusicCatalogResourceRequest<Song>(matching: \.id, equalTo: MusicItemID("APPLE_MUSIC_TRACK_ID"))
             if let response = try? await request.response() {
                 song = response.items.first
+                if let song {
+                    let player = ApplicationMusicPlayer.shared
+                    player.queue = [song]
+                    try? await player.play()
+                }
             }
         }
     }

--- a/README.md
+++ b/README.md
@@ -1,3 +1,3 @@
 # Glyrics
 
-This sample SwiftUI project demonstrates using MusicKit to display the official lyrics of a song along with phonetic and translated versions. Replace `APPLE_MUSIC_TRACK_ID` in `ContentView.swift` with the Apple Music track ID for "Χωρίς το μωρό μου" by Anna Vissi.
+This sample SwiftUI project demonstrates using MusicKit to play a song and display its official lyrics in sync with playback. Users can also tap a button to reveal phonetic and translated versions of the lyrics. Replace `APPLE_MUSIC_TRACK_ID` in `ContentView.swift` with the Apple Music track ID for "Χωρίς το μωρό μου" by Anna Vissi.


### PR DESCRIPTION
## Summary
- implement synced lyrics playback with `ApplicationMusicPlayer`
- allow toggling of phonetic and translated lyrics
- update README to mention playback and alternate lyrics toggle

## Testing
- `swift --version`
- `swift build` *(fails: Could not find Package.swift)*
- `xcodebuild -list` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_b_6882b6a8d060833090576fa7a539fb16